### PR TITLE
CORS 해결방법 변경(백서버 컨트롤러 @CrossOrigin -> 프론트서버 proxy)

### DIFF
--- a/board/board/package.json
+++ b/board/board/package.json
@@ -13,6 +13,7 @@
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
   },
+  "proxy": "http://localhost:8080",
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",

--- a/board/board/src/pages/jun/Jun.js
+++ b/board/board/src/pages/jun/Jun.js
@@ -10,7 +10,7 @@ import JunHeader from '../../components/JunHeader';
 function GetData() {
     const [data, setData] = useState({});
     useEffect(() => {
-        axios.get('http://localhost:8080/api/junboards').then((response) => {
+        axios.get('/api/junboards').then((response) => {
             setData(response.data);
         })
     }, []);

--- a/board/board/src/pages/jun/JunCreate.js
+++ b/board/board/src/pages/jun/JunCreate.js
@@ -8,7 +8,7 @@ const HandleCreateSubmit = async({body}) => {
         'Content-Type': 'application/json'
     }
 
-    const response = await axios.post('http://localhost:8080/api/junboards', body, {headers: headers}).then((response) => {
+    const response = await axios.post('/api/junboards', body, {headers: headers}).then((response) => {
         console.log('status : '+response.status);
         if(response.status === 200) {
             alert("저장되었습니다");

--- a/board/board/src/pages/jun/JunUpdate.js
+++ b/board/board/src/pages/jun/JunUpdate.js
@@ -16,7 +16,7 @@ const HandleUpdateSubmit = async(uid) => {
         'Content-Type': 'application/json'
     }
 
-    const response = await axios.put('http://localhost:8080/api/junboards/'+uid, body, {headers: headers}).then((response) => {
+    const response = await axios.put('/api/junboards/'+uid, body, {headers: headers}).then((response) => {
         console.log('status : '+response.status);
         if(response.status === 200) {
             alert("수정되었습니다");
@@ -33,7 +33,7 @@ function GetData(junId) {
     const [content, setContent] = useState();
 
     useEffect(() => {
-        axios.get('http://localhost:8080/api/junboards/'+junId).then((response)=> {
+        axios.get('/api/junboards/'+junId).then((response)=> {
             setTitle(response.data.title);
             setContent(response.data.content);
             setData(response.data);

--- a/board/board/src/pages/jun/JunView.js
+++ b/board/board/src/pages/jun/JunView.js
@@ -6,7 +6,7 @@ import './JunView.css'
 
 function JunDelete(props) {
     if(window.confirm("삭제하시겠습니까?")) {
-        axios.delete('http://localhost:8080/api/junboards/'+props).then((response)=> {
+        axios.delete('/api/junboards/'+props).then((response)=> {
             if(response.status === 200) {
                 alert("삭제되었습니다.");
                 window.location.href = "/jun"
@@ -20,7 +20,7 @@ function GetData(junId) {
     const [data, setData] = useState({});
 
     useEffect(() => {
-        axios.get('http://localhost:8080/api/junboards/'+junId).then((response)=> {
+        axios.get('/api/junboards/'+junId).then((response)=> {
             setData(response.data);
         })
     }, []);

--- a/boardApi/boardApi/src/main/java/com/board/boardback/controller/JunBoardController.java
+++ b/boardApi/boardApi/src/main/java/com/board/boardback/controller/JunBoardController.java
@@ -7,7 +7,6 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@CrossOrigin(origins = "http://localhost:3000")
 @RestController
 @RequestMapping("/api")
 public class JunBoardController {


### PR DESCRIPTION
cors 해결방법을 다른방식으로 변경해봤습니다.

기존에 백서버에서는 컨트롤러마다 @CrossOrigin을 추가해야했는데,

변경한 방법은 프론트서버에서 proxy를 활용하여 요청포트를 백서버와 동일하게하는 방법입니다.

자세한 내용은 아래 링크를 참고하시면 될 것 같습니다

https://dongjuppp.tistory.com/75

https://junhyunny.github.io/information/react/react-proxy/